### PR TITLE
Removed redundant multicast action on s3

### DIFF
--- a/lab4/streaming/streaming.p4
+++ b/lab4/streaming/streaming.p4
@@ -239,7 +239,7 @@ control MyEgress(inout headers hdr,
             mark_to_drop(standard_metadata);
         }
         if (standard_metadata.egress_port == 3 && standard_metadata.mcast_grp == 1) {
-            // Assume we are in s2 and sending to h3 via s3
+            // Assume we are in s2 and sending to h3 via s3 by multicast
             
             // Rewrite destination ip and mac, so the packet does not get dropped by h3
             hdr.ipv4.dstAddr = 0xA000303; // = 10.0.3.3 (h3) in hex

--- a/lab4/streaming/streaming.p4
+++ b/lab4/streaming/streaming.p4
@@ -243,7 +243,7 @@ control MyEgress(inout headers hdr,
             
             // Rewrite destination ip and mac, so the packet does not get dropped by h3
             hdr.ipv4.dstAddr = 0xA000303; // = 10.0.3.3 (h3) in hex
-            hdr.ethernet.dstAddr = 0x080000000333; // = 08:00:00:00:03:00 (s3) in hex
+            hdr.ethernet.dstAddr = 0x080000000300; // = 08:00:00:00:03:00 (s3) in hex
         }
     }
 }

--- a/lab4/streaming/streaming.p4
+++ b/lab4/streaming/streaming.p4
@@ -238,12 +238,12 @@ control MyEgress(inout headers hdr,
         if (standard_metadata.egress_port == standard_metadata.ingress_port) {
             mark_to_drop(standard_metadata);
         }
-        if (standard_metadata.egress_port == 1 && standard_metadata.mcast_grp == 1) {
-            // Assume we are in s3 and sending to h3
+        if (standard_metadata.egress_port == 3 && standard_metadata.mcast_grp == 1) {
+            // Assume we are in s2 and sending to h3 via s3
             
             // Rewrite destination ip and mac, so the packet does not get dropped by h3
-            hdr.ipv4.dstAddr = 0xA000303; // = 10.0.3.3 in hex
-            hdr.ethernet.dstAddr = 0x080000000333; // = 08:00:00:00:03:33 in hex
+            hdr.ipv4.dstAddr = 0xA000303; // = 10.0.3.3 (h3) in hex
+            hdr.ethernet.dstAddr = 0x080000000333; // = 08:00:00:00:03:00 (s3) in hex
         }
     }
 }

--- a/lab4/streaming/topo-isp/s3-runtime.json
+++ b/lab4/streaming/topo-isp/s3-runtime.json
@@ -36,23 +36,11 @@
             "match": {
                 "hdr.ipv4.dstAddr": ["10.0.7.7", 32]
             },
-            "action_name": "MyIngress.multicast",
-            "action_params" : {}
-        }
-    ],
-    "multicast_group_entries" : [
-        {
-          "multicast_group_id" : 1,
-          "replicas" : [
-            {
-              "egress_port" : 1,
-              "instance" : 1
-            },
-            {
-              "egress_port" : 3,
-              "instance" : 1
+            "action_name": "MyIngress.ipv4_forward",
+            "action_params": {
+                "dstAddr": "08:00:00:00:02:00",
+                "port": 3
             }
-          ]
         }
     ]
 }


### PR DESCRIPTION
Removed the redundant multicast action on s3, as we can simply do the multicast and rewriting **only** on s2.

---

Changes:
- Removed multicast action from s3
- Added logic to rewrite destination IP and MAC on s2 instead of s3.
  - Kept destination IP to `10.0.0.3` (h3)
  - Changed destination MAC to `08:00:00:00:03:00` (s3)

---

Proof of pingall:
![image](https://user-images.githubusercontent.com/15928604/147349982-259a828d-1839-491a-b645-87f4539ed659.png)


Proof of video interception:
![image](https://user-images.githubusercontent.com/15928604/147349948-9abaf96f-a4c7-4518-85ad-b6619e141cb6.png)
